### PR TITLE
FIX: Return long-form entities

### DIFF
--- a/ancpbids/query.py
+++ b/ancpbids/query.py
@@ -353,7 +353,7 @@ def query_entities(folder, scope: str = None, sort: bool = False, long_form=Fals
             result[key] = set()
         result[key].add(e.value)
     if long_form:
-        known_entities = {e.literal_: e.name for e in list(schema.EntityEnum)}
+        known_entities = schema_entities = {e.value['name']: e.name for e in list(schema.EntityEnum)}
         result = {known_entities[k] if k in known_entities else k: v for k, v in result.items()}
     if sort:
         result = {k: sorted(v) for k, v in sorted(result.items())}

--- a/ancpbids/query.py
+++ b/ancpbids/query.py
@@ -353,7 +353,7 @@ def query_entities(folder, scope: str = None, sort: bool = False, long_form=Fals
             result[key] = set()
         result[key].add(e.value)
     if long_form:
-        known_entities = schema_entities = {e.value['name']: e.name for e in list(schema.EntityEnum)}
+        known_entities = {e.value['name']: e.name for e in list(schema.EntityEnum)}
         result = {known_entities[k] if k in known_entities else k: v for k, v in result.items()}
     if sort:
         result = {k: sorted(v) for k, v in sorted(result.items())}


### PR DESCRIPTION
I was getting an error when using `long_form=True` for get_entities.

Since pybids prefers the long_form, I want to default to that in `BIDSLayout` when possible.

This was the error:

```
AttributeError: 'EntityEnum' object has no attribute 'literal_'
```