### PR TITLE
Unpin the wheel build dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel==0.30.0"]
+requires = ["setuptools", "wheel>=0.30.0"]


### PR DESCRIPTION
I would like to use this project with newer versions of `wheel` in [nixpkgs](https://github.com/NixOS/nixpkgs).