### PR TITLE
updated load_dataset to allow pathlib objects as path

### DIFF
--- a/ancpbids/__init__.py
+++ b/ancpbids/__init__.py
@@ -66,6 +66,7 @@ def load_dataset(base_dir: str, options: Optional[DatasetOptions] = None):
     str
         a Dataset object depending on the used schema which represents the dataset as an in-memory graph
     """
+    base_dir = str(base_dir)
     if not os.path.isdir(base_dir):
         raise ValueError("Invalid Directory")
     schema = load_schema(base_dir)


### PR DESCRIPTION
💡 Pull Request: Support for pathlib.Path Objects as Dataset Path, fixes #98
✨ Changes Introduced:
- Added support for pathlib.Path objects as valid inputs for base_dir.
- Internally cast base_dir to str to ensure compatibility across all path-handling logic.

Closes #98 